### PR TITLE
Allow passing array of arrays to Box extend

### DIFF
--- a/src/components/Box.js
+++ b/src/components/Box.js
@@ -140,7 +140,7 @@ Box.defaultProps = {
   wrap: 'nowrap',
 }
 
-const ruleType = PropTypes.oneOfType([PropTypes.object, PropTypes.func])
+const ruleType = PropTypes.oneOfType([PropTypes.object, PropTypes.func, PropTypes.array])
 
 Box.propTypes = {
   /** The HTML node that is rendered. */


### PR DESCRIPTION
To be able to do something like:

```jsx
const Card = forwardRef(({ children, extend, ...props }, ref) => (
  <Box {...props} ref={ref} extend={[style, extend]}>
    {children}
  </Box>
))
```