### PR TITLE
Box: spaceType 

### DIFF
--- a/src/components/Box.js
+++ b/src/components/Box.js
@@ -25,19 +25,20 @@ function renderChildren(children, spaceType, space, direction) {
   const filledDir = fillArrayByLength(dirArr, length)
   const filledSpace = fillArrayByLength(spaceArr, length)
 
+  const margins = {
+    marginRight: filledDir.map((dir, i) =>
+      dir === 'row' || dir === 'row-reverse' ? filledSpace[i] : 0
+    ),
+    marginBottom: filledDir.map((dir, i) =>
+      dir === 'row' || dir === 'row-reverse' ? 0 : filledSpace[i]
+    ),
+  }
+
   return Children.toArray(children).map((child, index, arr) =>
     index === arr.length - 1 ? (
-      child
+      <Box>{child}</Box>
     ) : (
-      <Box
-        marginRight={filledDir.map((dir, i) =>
-          dir === 'row' || dir === 'row-reverse' ? filledSpace[i] : 0
-        )}
-        marginBottom={filledDir.map((dir, i) =>
-          dir === 'row' || dir === 'row-reverse' ? 0 : filledSpace[i]
-        )}>
-        {child}
-      </Box>
+      <Box {...margins}>{child}</Box>
     )
   )
 }

--- a/src/components/Box.js
+++ b/src/components/Box.js
@@ -8,6 +8,40 @@ import applyMultiplier from '../utils/applyMultiplier'
 import fillArrayByLength from '../utils/fillArrayByLength'
 import arrayifyValue from '../utils/arrayifyValue'
 
+function renderChildren(children, spaceType, space, direction) {
+  if (spaceType === 'spacer') {
+    return Children.toArray(children).map((child, index, arr) => (
+      <React.Fragment key={index}>
+        {child}
+        {index === arr.length - 1 ? null : <Spacer size={space} />}
+      </React.Fragment>
+    ))
+  }
+
+  const dirArr = arrayifyValue(direction)
+  const spaceArr = arrayifyValue(space)
+
+  const length = Math.max(dirArr.length, spaceArr.length)
+  const filledDir = fillArrayByLength(dirArr, length)
+  const filledSpace = fillArrayByLength(spaceArr, length)
+
+  return Children.toArray(children).map((child, index, arr) =>
+    index === arr.length - 1 ? (
+      child
+    ) : (
+      <Box
+        marginRight={filledDir.map((dir, i) =>
+          dir === 'row' || dir === 'row-reverse' ? filledSpace[i] : 0
+        )}
+        marginBottom={filledDir.map((dir, i) =>
+          dir === 'row' || dir === 'row-reverse' ? 0 : filledSpace[i]
+        )}>
+        {child}
+      </Box>
+    )
+  )
+}
+
 const Box = forwardRef(
   (
     {
@@ -94,39 +128,7 @@ const Box = forwardRef(
           extend
         )}>
         {space
-          ? Children.toArray(children).map((child, index, arr) => {
-              if (spaceType === 'spacer') {
-                return (
-                  <React.Fragment key={index}>
-                    {child}
-                    {index === arr.length - 1 ? null : <Spacer size={space} />}
-                  </React.Fragment>
-                )
-              }
-
-              const dirArr = arrayifyValue(direction)
-              const spaceArr = arrayifyValue(space)
-
-              const length = Math.max(dirArr.length, spaceArr.length)
-              const filledDir = fillArrayByLength(dirArr, length)
-              const filledSpace = fillArrayByLength(spaceArr, length)
-
-              if (index === arr.length - 1) {
-                return child
-              }
-
-              return (
-                <Box
-                  marginRight={filledDir.map((dir, i) =>
-                    dir === 'row' || dir === 'row-reverse' ? filledSpace[i] : 0
-                  )}
-                  marginBottom={filledDir.map((dir, i) =>
-                    dir === 'row' || dir === 'row-reverse' ? 0 : filledSpace[i]
-                  )}>
-                  {child}
-                </Box>
-              )
-            })
+          ? renderChildren(children, spaceType, space, direction)
           : children}
       </As>
     )

--- a/src/utils/arrayifyValue.js
+++ b/src/utils/arrayifyValue.js
@@ -1,0 +1,3 @@
+export default function arrayifyValue(value) {
+  return [].concat(value)
+}

--- a/src/utils/fillArrayByLength.js
+++ b/src/utils/fillArrayByLength.js
@@ -1,0 +1,9 @@
+export default function fillArray(arr, length) {
+  for (let i = 0; i < length; ++i) {
+    if (arr[i] === undefined) {
+      arr[i] = arr[i - 1 || 0]
+    }
+  }
+
+  return arr
+}


### PR DESCRIPTION
This PR implements a new `spaceType` prop on **Box**.

It supports 2 different values: `spacer` and `container`.
Both space types render the same visual result, but the DOM tree looks different and is interpreted differently by screen readers.

## Spacer
This is the default behaviour we already know, adding a **Spacer** component in between all children.
The implementation is straight-forward and works due to flexbox directions.
The only problem: It breaks A11y on e.g. lists or navigations. It also messes with `:nth-child` pseudos.

## Container
The solution for the problem is the new container behaviour.
Instead of adding a new element in between, we wrap each child with a container that applies the correct spacing via margin.
We map over the passed `direction` value to either set `marginRight` or `marginBottom`.